### PR TITLE
Fixed issue with exporting ~/graphql-client to a project

### DIFF
--- a/template/lib/graphql-client/client.js
+++ b/template/lib/graphql-client/client.js
@@ -1,10 +1,10 @@
-const { query } = require('./query')
-const { mutate } = require('./mutate')
-const { subscribe } = require('./subscribe')
-const { createClient } = require('./createClient')
-const { vuex } = require('./vuex')
+import  query from './query'
+import  mutate from './mutate'
+import  subscribe from './subscribe'
+import  createClient from './createClient'
+import  vuex from './vuex'
 
-module.exports = class GraphQLClient {
+export default class GraphQLClient {
   constructor (config) {
     this.config = config
     this.clients = Object.entries(config.clients).reduce((clients, [name, client]) => {

--- a/template/lib/graphql-client/mutate.js
+++ b/template/lib/graphql-client/mutate.js
@@ -1,6 +1,6 @@
 const _cloneDeep = require('lodash/cloneDeep')
 
-module.exports = async function mutate (mutation, { variables, client = 'default' }) {
+export default async function (mutation, { variables, client = 'default' }) {
   try {
     const response = await this.clients[client].mutate({
       mutation,

--- a/template/lib/graphql-client/query.js
+++ b/template/lib/graphql-client/query.js
@@ -1,6 +1,6 @@
 const _cloneDeep = require('lodash/cloneDeep')
 
-module.exports = async function query (query, { variables, client = 'default' } = { variables: {} }) {
+export default async function (query, { variables, client = 'default' } = { variables: {} }) {
   try {
     const response = await this.clients[client].query({
       query: query,
@@ -26,5 +26,3 @@ module.exports = async function query (query, { variables, client = 'default' } 
     }
   }
 }
-
-export default query

--- a/template/lib/graphql-client/subscribe.js
+++ b/template/lib/graphql-client/subscribe.js
@@ -1,4 +1,4 @@
-module.exports = function subscribe (subscriptionQuery, { error, ...options }) {
+export default function (subscriptionQuery, { error, ...options }) {
   options.client = options.client || 'default'
 
   try {
@@ -28,5 +28,3 @@ module.exports = function subscribe (subscriptionQuery, { error, ...options }) {
     return null
   }
 }
-
-export default subscribe


### PR DESCRIPTION
I had an eslint error during using the graphql-client from the template:  'query' was not defined in #/lib/graphql-client/query.js. I've replaced "module.exports" with "export default".